### PR TITLE
Simple lambda inference

### DIFF
--- a/src/extract/expr/name.rs
+++ b/src/extract/expr/name.rs
@@ -16,6 +16,7 @@ pub fn apply<'def, 'def_ref, 'overlay_ref>(
         ResolvedName::Class(c) => Definition::Class(c),
         ResolvedName::Variable(v) => Definition::VariableDeclarator(v),
         ResolvedName::TypeParam(t) => Definition::TypeParam(t),
+        ResolvedName::Param(p) => Definition::Param(p),
     };
 
     overlay.usages.push(Usage {

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -27,6 +27,7 @@ pub enum Definition<'a> {
     Method(*const analyze::definition::MethodDef<'a>),
     Field(*const analyze::definition::FieldDef<'a>),
     TypeParam(*const analyze::definition::TypeParam<'a>),
+    Param(*const analyze::definition::Param<'a>),
     VariableDeclarator(*const VariableDeclarator<'a>),
 }
 
@@ -39,6 +40,7 @@ impl<'a> Definition<'a> {
             Definition::VariableDeclarator(v) => *v as usize,
             Definition::Field(f) => *f as usize,
             Definition::TypeParam(t) => *t as usize,
+            Definition::Param(p) => *p as usize,
         }
     }
     pub fn span(&self) -> Option<&Span<'a>> {
@@ -52,6 +54,7 @@ impl<'a> Definition<'a> {
                 Some(&v.name)
             }
             Definition::TypeParam(t) => unsafe { &**t }.span_opt.as_ref(),
+            Definition::Param(p) => Some(&unsafe { &**p }.name),
         }
     }
 }

--- a/src/parse/expr/atom/lambda.rs
+++ b/src/parse/expr/atom/lambda.rs
@@ -78,6 +78,9 @@ pub fn parse<'def, 'r>(
     Ok((
         input,
         Expr::Lambda(Lambda {
+            inferred_method_opt: None,
+            inferred_params: vec![],
+            inferred_return_type: Type::UnknownType,
             params,
             expr_opt,
             block_opt,

--- a/src/parse/statement/block.rs
+++ b/src/parse/statement/block.rs
@@ -1,6 +1,6 @@
 use parse::combinator::{many0, symbol};
 use parse::id_gen::IdGen;
-use parse::tree::{Block, Statement};
+use parse::tree::{Block, Statement, Type};
 use parse::{statement, ParseResult, Tokens};
 
 pub fn parse_block_or_single_statement<'def, 'r>(
@@ -11,7 +11,13 @@ pub fn parse_block_or_single_statement<'def, 'r>(
         Ok(ok)
     } else {
         let (input, stmt) = statement::parse(input, id_gen)?;
-        Ok((input, Block { stmts: vec![stmt] }))
+        Ok((
+            input,
+            Block {
+                stmts: vec![stmt],
+                return_type: Type::UnknownType,
+            },
+        ))
     }
 }
 
@@ -23,7 +29,13 @@ pub fn parse_block<'def, 'r>(
     let (input, stmts) = many0(|i| statement::parse(i, id_gen))(input)?;
     let (input, _) = symbol('}')(input)?;
 
-    Ok((input, Block { stmts }))
+    Ok((
+        input,
+        Block {
+            stmts,
+            return_type: Type::UnknownType,
+        },
+    ))
 }
 
 pub fn parse<'def, 'r>(

--- a/src/semantics/block.rs
+++ b/src/semantics/block.rs
@@ -2,12 +2,9 @@ use analyze::resolve::scope::Scope;
 use parse::tree::Block;
 use semantics::{statement, Context};
 
-pub fn apply<'def, 'def_ref>(
-    block: &'def_ref Block<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
-) {
+pub fn apply<'def>(block: &mut Block<'def>, context: &mut Context<'def, '_, '_>) {
     context.scope.enter();
-    for stmt in &block.stmts {
+    for stmt in &mut block.stmts {
         statement::apply(stmt, context);
     }
     context.scope.leave();

--- a/src/semantics/compilation_unit.rs
+++ b/src/semantics/compilation_unit.rs
@@ -4,9 +4,9 @@ use semantics::def::class;
 use semantics::{import, Context};
 use {analyze, parse};
 
-pub fn apply<'def, 'def_ref>(
-    unit: &'def_ref mut parse::tree::CompilationUnit<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
+pub fn apply<'def>(
+    unit: &mut parse::tree::CompilationUnit<'def>,
+    context: &mut Context<'def, '_, '_>,
 ) {
     if let Some(package) = &unit.package_opt {
         enter_package(package, context);
@@ -14,7 +14,7 @@ pub fn apply<'def, 'def_ref>(
         context.scope.enter();
     }
 
-    for im in &unit.imports {
+    for im in &mut unit.imports {
         context.scope.add_import(im);
         import::apply(im, context);
     }
@@ -30,10 +30,7 @@ pub fn apply<'def, 'def_ref>(
     }
 }
 
-fn apply_item<'def, 'def_ref>(
-    item: &'def_ref mut CompilationUnitItem<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
-) {
+fn apply_item<'def>(item: &mut CompilationUnitItem<'def>, context: &mut Context<'def, '_, '_>) {
     match item {
         CompilationUnitItem::Class(c) => class::apply(c, context),
         CompilationUnitItem::Interface(_) => panic!(),
@@ -42,10 +39,7 @@ fn apply_item<'def, 'def_ref>(
     };
 }
 
-fn enter_package<'def, 'def_ref>(
-    package: &'def_ref parse::tree::Package<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
-) {
+fn enter_package<'def>(package: &parse::tree::Package<'def>, context: &mut Context<'def, '_, '_>) {
     if let Some(prefix) = &package.prefix_opt {
         enter_package(prefix, context);
         match context
@@ -74,10 +68,7 @@ fn enter_package<'def, 'def_ref>(
     }
 }
 
-fn leave_package<'def, 'def_ref>(
-    package: &'def_ref parse::tree::Package<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
-) {
+fn leave_package<'def>(package: &parse::tree::Package<'def>, context: &mut Context<'def, '_, '_>) {
     if let Some(prefix) = &package.prefix_opt {
         leave_package(prefix, context);
     }

--- a/src/semantics/def/class.rs
+++ b/src/semantics/def/class.rs
@@ -5,10 +5,7 @@ use semantics::Context;
 use std::borrow::Borrow;
 use {analyze, parse};
 
-pub fn apply<'def, 'def_ref>(
-    class: &'def_ref mut parse::tree::Class<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
-) {
+pub fn apply<'def>(class: &mut parse::tree::Class<'def>, context: &mut Context<'def, '_, '_>) {
     class.def_opt.replace(Some(
         context
             .id_hash
@@ -34,9 +31,9 @@ pub fn apply<'def, 'def_ref>(
     context.scope.leave();
 }
 
-fn apply_class_body<'def, 'def_ref, 'scope_ref>(
-    body: &'def_ref mut parse::tree::ClassBody<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
+fn apply_class_body<'def>(
+    body: &mut parse::tree::ClassBody<'def>,
+    context: &mut Context<'def, '_, '_>,
 ) {
     for item in &mut body.items {
         match item {

--- a/src/semantics/def/field.rs
+++ b/src/semantics/def/field.rs
@@ -2,18 +2,18 @@ use analyze::resolve::scope::Scope;
 use semantics::{block, Context};
 use {analyze, parse};
 
-pub fn apply<'def, 'def_ref>(
-    field_declarators: &'def_ref parse::tree::FieldDeclarators<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
+pub fn apply<'def>(
+    field_declarators: &mut parse::tree::FieldDeclarators<'def>,
+    context: &mut Context<'def, '_, '_>,
 ) {
-    for decl in &field_declarators.declarators {
+    for decl in &mut field_declarators.declarators {
         apply_decl(decl, context);
     }
 }
 
-pub fn apply_decl<'def, 'def_ref>(
-    decl: &'def_ref parse::tree::FieldDeclarator<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
+pub fn apply_decl<'def>(
+    decl: &mut parse::tree::FieldDeclarator<'def>,
+    context: &mut Context<'def, '_, '_>,
 ) {
     decl.def_opt.replace(Some(
         context

--- a/src/semantics/def/method.rs
+++ b/src/semantics/def/method.rs
@@ -3,10 +3,7 @@ use semantics::def::type_param;
 use semantics::{block, Context};
 use {analyze, parse};
 
-pub fn apply<'def, 'def_ref>(
-    method: &'def_ref mut parse::tree::Method<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
-) {
+pub fn apply<'def>(method: &mut parse::tree::Method<'def>, context: &mut Context<'def, '_, '_>) {
     method.def_opt.replace(Some(
         context
             .id_hash
@@ -20,7 +17,7 @@ pub fn apply<'def, 'def_ref>(
         type_param::apply(t, context);
     }
 
-    if let Some(blk) = &method.block_opt {
+    if let Some(blk) = &mut method.block_opt {
         block::apply(blk, context);
     }
 

--- a/src/semantics/def/type_param.rs
+++ b/src/semantics/def/type_param.rs
@@ -2,9 +2,9 @@ use analyze::resolve;
 use semantics::Context;
 use {analyze, parse};
 
-pub fn apply<'def, 'def_ref>(
-    type_param: &'def_ref mut parse::tree::TypeParam<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
+pub fn apply<'def>(
+    type_param: &mut parse::tree::TypeParam<'def>,
+    context: &mut Context<'def, '_, '_>,
 ) {
     let def = context
         .id_hash

--- a/src/semantics/expr/lambda.rs
+++ b/src/semantics/expr/lambda.rs
@@ -1,0 +1,187 @@
+use analyze;
+use analyze::definition::{Param, TypeParam};
+use analyze::resolve::scope::Scope;
+use parse::tree::{ClassType, Lambda, Name, ParameterizedType, Type};
+use semantics::expr::method_call::coerce_from_primitive_to_class;
+use semantics::{block, expr, Context};
+use std::cell::RefCell;
+use std::ops::Deref;
+
+pub fn apply<'def>(
+    lambda: &mut Lambda<'def>,
+    target_type: &Type<'def>,
+    context: &mut Context<'def, '_, '_>,
+) {
+    lambda.inferred_method_opt = get_lambda_method(target_type);
+
+    context.scope.enter();
+
+    if let Some(method) = &mut lambda.inferred_method_opt {
+        for (param, target_param) in lambda.params.iter().zip(method.params.iter()) {
+            lambda.inferred_params.push(Param {
+                tpe: RefCell::new(infer(
+                    &param.tpe,
+                    target_param.tpe.borrow().deref(),
+                    context,
+                )),
+                name: param.name.clone(),
+                is_varargs: param.is_varargs,
+            });
+        }
+    }
+
+    for param in &lambda.inferred_params {
+        context.scope.add_param(param);
+    }
+
+    if let Some(e) = &mut lambda.expr_opt {
+        expr::apply(e, &Type::UnknownType, context);
+
+        lambda.inferred_return_type = e.tpe_opt().unwrap_or(Type::UnknownType);
+    } else if let Some(b) = &mut lambda.block_opt {
+        block::apply(b, context);
+
+        lambda.inferred_return_type = b.return_type.clone();
+    }
+
+    if let Some(method) = &lambda.inferred_method_opt {
+        lambda.inferred_return_type =
+            infer(&lambda.inferred_return_type, &method.return_type, context);
+    }
+
+    context.scope.leave();
+}
+
+fn infer<'def>(
+    declared: &Type<'def>,
+    target: &Type<'def>,
+    context: &Context<'def, '_, '_>,
+) -> Type<'def> {
+    match declared {
+        Type::Class(declared) => return Type::Class(infer_class(declared, target)),
+        Type::Primitive(p) => return Type::Primitive(p.clone()),
+        Type::Parameterized(declared) => return infer_parameterized(declared, target, context),
+        Type::Array(_) => (),
+        Type::Wildcard(_) => (),
+        Type::UnknownType => return target.clone(),
+        Type::Void(_) => panic!(),
+    }
+
+    declared.clone()
+}
+
+fn infer_parameterized<'def>(
+    declared: &ParameterizedType<'def>,
+    target: &Type<'def>,
+    context: &Context<'def, '_, '_>,
+) -> Type<'def> {
+    match target {
+        Type::Primitive(p) => return Type::Class(coerce_from_primitive_to_class(p, context)),
+        Type::Class(c) => return Type::Class(c.clone()),
+        _ => (),
+    };
+
+    Type::Parameterized(declared.clone())
+}
+
+fn infer_class<'def>(declared: &ClassType<'def>, target: &Type<'def>) -> ClassType<'def> {
+    match target {
+        Type::Class(target) => {
+            let equal_with_def = declared.def_opt.is_some() && declared.def_opt == target.def_opt;
+            let equal_without_def = declared.def_opt.is_none()
+                && target.def_opt.is_none()
+                && declared.name == target.name;
+            if equal_with_def || equal_without_def {
+                // TODO: we need to recursively handle prefix_opt and type_args_opt
+                return ClassType {
+                    prefix_opt: None,
+                    name: declared.name.clone(),
+                    span_opt: declared.span_opt,
+                    // TODO: what do we do if `target` has `type_args` but `declared` doesn't? And vice versa
+                    // TODO: what do we do if they have different numbers of `type_args`?
+                    type_args_opt: None,
+                    def_opt: declared.def_opt,
+                };
+            }
+        }
+        _ => (),
+    }
+
+    declared.clone()
+}
+
+fn get_lambda_method<'def>(target_type: &Type<'def>) -> Option<analyze::definition::Method<'def>> {
+    let target_type = if let Type::Class(t) = target_type {
+        t
+    } else {
+        return None;
+    };
+
+    target_type.lambda_method()
+}
+
+#[cfg(test)]
+mod tests {
+    use analyze::definition::Param;
+    use parse::tree::{
+        ClassBodyItem, ClassType, CompilationUnitItem, Expr, PrimitiveType, PrimitiveTypeType,
+        ResolvedName, Statement, Type, TypeParam,
+    };
+    use std::cell::RefCell;
+    use std::ops::Deref;
+    use test_common::span2;
+
+    #[test]
+    fn test_simple() {
+        let (files, root) = apply_semantics!(
+            r#"
+package dev;
+
+class Test {
+  void method() {
+    method((a) -> { return a; });
+  }
+  
+  void method(Function fn) {}
+}
+        "#,
+            r#"
+package dev;
+
+abstract class Function {
+  int main(int a);
+}
+        "#
+        );
+
+        let class = unwrap!(
+            CompilationUnitItem::Class,
+            &files.first().unwrap().unit.items.get(0).unwrap()
+        );
+        let method = unwrap!(ClassBodyItem::Method, &class.body.items.get(0).unwrap());
+        let expr_stmt = unwrap!(
+            Statement::Expr,
+            &method.block_opt.as_ref().unwrap().stmts.get(0).unwrap()
+        );
+        let method_call = unwrap!(Expr::MethodCall, &expr_stmt);
+
+        let lambda = unwrap!(Expr::Lambda, method_call.args.get(0).unwrap());
+
+        let return_stmt = unwrap!(
+            Statement::Return,
+            lambda.block_opt.as_ref().unwrap().stmts.get(0).unwrap()
+        );
+        let return_expr = unwrap!(Expr::Name, return_stmt.expr_opt.as_ref().unwrap());
+
+        let param =
+            unsafe { &*unwrap!(ResolvedName::Param, return_expr.resolved_opt.get().unwrap()) };
+
+        assert_eq!(
+            param.tpe.borrow().deref(),
+            &Type::Primitive(PrimitiveType {
+                span_opt: Some(span2(4, 12, "int", files.get(1).unwrap().deref())),
+                tpe: PrimitiveTypeType::Int
+            })
+        )
+    }
+}

--- a/src/semantics/expr/mod.rs
+++ b/src/semantics/expr/mod.rs
@@ -3,13 +3,14 @@ use parse::tree::{Expr, Type};
 use semantics::Context;
 
 pub mod field_access;
+pub mod lambda;
 pub mod method_call;
 pub mod name;
 
-pub fn apply<'def, 'def_ref, 'scope_ref>(
-    expr: &'def_ref Expr<'def>,
-    //    target_type: &Type<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
+pub fn apply<'def>(
+    expr: &mut Expr<'def>,
+    target_type: &Type<'def>,
+    context: &mut Context<'def, '_, '_>,
 ) {
     match expr {
         Expr::FieldAccess(f) => field_access::apply(f, context),
@@ -26,7 +27,7 @@ pub fn apply<'def, 'def_ref, 'scope_ref>(
         Expr::Hex(_) => {}
         Expr::InstanceOf(_) => {}
         Expr::Int(_) => {}
-        Expr::Lambda(_) => {}
+        Expr::Lambda(l) => lambda::apply(l, target_type, context),
         Expr::Long(_) => {}
         Expr::MethodCall(m) => method_call::apply(m, context),
         Expr::MethodReference(_) => {}

--- a/src/semantics/expr/name.rs
+++ b/src/semantics/expr/name.rs
@@ -2,10 +2,7 @@ use analyze::resolve::scope::Scope;
 use parse::tree::Name;
 use semantics::Context;
 
-pub fn apply<'def, 'def_ref, 'scope_ref>(
-    name: &'def_ref Name<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
-) {
+pub fn apply<'def>(name: &mut Name<'def>, context: &mut Context<'def, '_, '_>) {
     name.resolved_opt
         .set(context.scope.resolve_name(name.name.fragment));
 }

--- a/src/semantics/import.rs
+++ b/src/semantics/import.rs
@@ -3,27 +3,24 @@ use parse::tree::{ImportDef, ImportPrefix, ImportPrefixDef};
 use semantics::Context;
 use {analyze, parse};
 
-pub fn apply<'def, 'def_ref>(
-    import: &parse::tree::Import<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
-) {
-    match &import.prefix_opt {
+pub fn apply<'def>(import: &mut parse::tree::Import<'def>, context: &mut Context<'def, '_, '_>) {
+    match &mut import.prefix_opt {
         Some(prefix) => apply_prefix(prefix, context),
         None => (),
     };
 
     import.def_opt.replace(get_def(
-        &import.prefix_opt,
+        &mut import.prefix_opt,
         import.name.fragment,
         &mut context.scope,
     ));
 }
 
-pub fn apply_prefix<'def, 'def_ref>(
-    import: &parse::tree::ImportPrefix<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
+pub fn apply_prefix<'def>(
+    import: &mut parse::tree::ImportPrefix<'def>,
+    context: &mut Context<'def, '_, '_>,
 ) {
-    match &import.prefix_opt {
+    match &mut import.prefix_opt {
         Some(prefix) => apply_prefix(prefix, context),
         None => (),
     };
@@ -35,10 +32,10 @@ pub fn apply_prefix<'def, 'def_ref>(
     ));
 }
 
-fn get_def<'def, 'def_ref>(
-    prefix_opt: &Option<Box<ImportPrefix<'def>>>,
+fn get_def<'def>(
+    prefix_opt: &mut Option<Box<ImportPrefix<'def>>>,
     name: &'def str,
-    scope: &mut Scope<'def, 'def_ref>,
+    scope: &mut Scope<'def, '_>,
 ) -> Option<ImportDef<'def>> {
     let result_opt = get_enclosing_type_def(prefix_opt, name, scope);
 
@@ -49,10 +46,10 @@ fn get_def<'def, 'def_ref>(
     }
 }
 
-fn get_prefix_def<'def, 'def_ref>(
+fn get_prefix_def<'def>(
     prefix_opt: &Option<Box<ImportPrefix<'def>>>,
     name: &'def str,
-    scope: &mut Scope<'def, 'def_ref>,
+    scope: &mut Scope<'def, '_>,
 ) -> Option<ImportPrefixDef<'def>> {
     let result_opt = get_enclosing_type_def(prefix_opt, name, scope);
 
@@ -63,10 +60,10 @@ fn get_prefix_def<'def, 'def_ref>(
     }
 }
 
-fn get_enclosing_type_def<'def, 'def_ref>(
+fn get_enclosing_type_def<'def>(
     prefix_opt: &Option<Box<ImportPrefix<'def>>>,
     name: &'def str,
-    scope: &mut Scope<'def, 'def_ref>,
+    scope: &mut Scope<'def, '_>,
 ) -> Option<EnclosingTypeDef<'def>> {
     match prefix_opt {
         Some(prefix) => match prefix.def_opt.borrow().as_ref() {

--- a/src/semantics/statement/mod.rs
+++ b/src/semantics/statement/mod.rs
@@ -1,16 +1,15 @@
 use analyze::resolve::scope::Scope;
-use parse::tree::Statement;
+use parse::tree::{Statement, Type};
 use semantics::{expr, Context};
 
+pub mod return_stmt;
 pub mod variable_declarators;
 
-pub fn apply<'def, 'def_ref, 'scope_ref>(
-    stmt: &'def_ref Statement<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
-) {
+pub fn apply<'def>(stmt: &mut Statement<'def>, context: &mut Context<'def, '_, '_>) {
     match stmt {
         Statement::VariableDeclarators(v) => variable_declarators::apply(v, context),
-        Statement::Expr(e) => expr::apply(e, context),
+        Statement::Expr(e) => expr::apply(e, &Type::UnknownType, context),
+        Statement::Return(r) => return_stmt::apply(r, context),
         _ => (),
     };
 }

--- a/src/semantics/statement/return_stmt.rs
+++ b/src/semantics/statement/return_stmt.rs
@@ -1,0 +1,8 @@
+use parse::tree::{ReturnStmt, Type};
+use semantics::{expr, Context};
+
+pub fn apply<'def>(return_stmt: &mut ReturnStmt<'def>, context: &mut Context<'def, '_, '_>) {
+    if let Some(e) = &mut return_stmt.expr_opt {
+        expr::apply(e, &Type::UnknownType, context);
+    }
+}

--- a/src/semantics/statement/variable_declarators.rs
+++ b/src/semantics/statement/variable_declarators.rs
@@ -2,19 +2,20 @@ use analyze::resolve;
 use analyze::resolve::scope::Scope;
 use parse::tree::{VariableDeclarator, VariableDeclarators};
 use semantics::{expr, Context};
+use std::ops::Deref;
 
-pub fn apply<'def, 'def_ref, 'scope_ref>(
-    declarator: &'def_ref VariableDeclarators<'def>,
-    context: &mut Context<'def, 'def_ref, '_>,
+pub fn apply<'def>(
+    declarator: &mut VariableDeclarators<'def>,
+    context: &mut Context<'def, '_, '_>,
 ) {
-    for decl in &declarator.declarators {
+    for decl in &mut declarator.declarators {
         let resolved = resolve::apply_type(&decl.tpe.borrow(), &mut context.scope);
         decl.tpe.replace(resolved);
 
         context.scope.add_variable(decl);
 
-        if let Some(ex) = &decl.expr_opt {
-            expr::apply(ex, context);
+        if let Some(ex) = &mut decl.expr_opt {
+            expr::apply(ex, decl.tpe.borrow().deref(), context);
         }
     }
 }


### PR DESCRIPTION
* Infer primitive type into a type param
* Use `mut` instead of `RefCell`. We still need to remove `RefCell` usages.